### PR TITLE
Indicator Disable Option

### DIFF
--- a/SashimiSlayer/Assets/Scripts/Beatmapping/Indicator/NoteTimingIndicator.cs
+++ b/SashimiSlayer/Assets/Scripts/Beatmapping/Indicator/NoteTimingIndicator.cs
@@ -58,6 +58,11 @@ namespace Beatmapping.Indicator
             }
             else
             {
+                if (_lastInteraction == null)
+                {
+                    return;
+                }
+
                 // Not an interaction; hide all indicators
                 _sliceTimingIndicators.SetVisible(false);
                 foreach (PipTimingIndicator blockTimingIndicator in _blockTimingIndicators)
@@ -82,6 +87,8 @@ namespace Beatmapping.Indicator
         private void SwitchIndicators(NoteInteraction interaction, BeatmapConfigSo currentBeatmap,
             bool firstInteraction)
         {
+            bool hideIndicator = interaction.HideIndicator;
+
             if (interaction.Type == NoteInteraction.InteractionType.Block)
             {
                 // Select matching block indicator
@@ -89,7 +96,7 @@ namespace Beatmapping.Indicator
                 _blockTimingIndicators[blockIndex].SetupNewInteraction(currentBeatmap, firstInteraction);
                 for (var i = 0; i < _blockTimingIndicators.Count; i++)
                 {
-                    _blockTimingIndicators[i].SetVisible(i == blockIndex);
+                    _blockTimingIndicators[i].SetVisible(i == blockIndex && !hideIndicator);
                 }
 
                 _currentActiveIndicator = _blockTimingIndicators[blockIndex];
@@ -98,8 +105,8 @@ namespace Beatmapping.Indicator
             }
             else if (interaction.Type == NoteInteraction.InteractionType.Slice)
             {
-                _sliceTimingIndicators.SetVisible(true);
                 _sliceTimingIndicators.SetupNewInteraction(currentBeatmap, firstInteraction);
+                _sliceTimingIndicators.SetVisible(!hideIndicator);
                 _currentActiveIndicator = _sliceTimingIndicators;
 
                 // Hide all block indicators

--- a/SashimiSlayer/Assets/Scripts/Beatmapping/Interactions/NoteInteraction.cs
+++ b/SashimiSlayer/Assets/Scripts/Beatmapping/Interactions/NoteInteraction.cs
@@ -49,13 +49,16 @@ namespace Beatmapping.Interactions
 
         public SharedTypes.BlockPoseStates BlockPose { get; }
 
+        public bool HideIndicator { get; private set; }
+
         private readonly TimingWindow _timingWindow;
 
         public NoteInteraction(InteractionType typeType,
             InteractionFlags interactionFlags,
             SharedTypes.BlockPoseStates blockPose,
             List<Vector2> positions,
-            TimingWindow window)
+            TimingWindow window,
+            bool hideIndicator)
         {
             Type = typeType;
             Flags = interactionFlags;
@@ -63,6 +66,7 @@ namespace Beatmapping.Interactions
             _timingWindow = window;
             Positions = positions == null ? null : new List<Vector2>(positions);
             State = NoteInteractionState.Default;
+            HideIndicator = hideIndicator;
         }
 
         public void ResetState()

--- a/SashimiSlayer/Assets/Scripts/Beatmapping/Interactions/NoteInteractionData.cs
+++ b/SashimiSlayer/Assets/Scripts/Beatmapping/Interactions/NoteInteractionData.cs
@@ -24,7 +24,7 @@ namespace Beatmapping.Interactions
         [HideInInspector]
         public NoteInteraction.InteractionFlags Flags;
 
-        [Tooltip("Show Indicator")]
+        [Tooltip("Hide Timing Indicator")]
         public bool HideIndicator;
 
         [FormerlySerializedAs("InteractionPositions")]

--- a/SashimiSlayer/Assets/Scripts/Beatmapping/Interactions/NoteInteractionData.cs
+++ b/SashimiSlayer/Assets/Scripts/Beatmapping/Interactions/NoteInteractionData.cs
@@ -24,13 +24,16 @@ namespace Beatmapping.Interactions
         [HideInInspector]
         public NoteInteraction.InteractionFlags Flags;
 
+        [Tooltip("Show Indicator")]
+        public bool HideIndicator;
+
         [FormerlySerializedAs("InteractionPositions")]
         [Tooltip("Positions for the interaction")]
         public List<Vector2> Positions;
 
         public NoteInteraction ToNoteInteraction(TimingWindow window)
         {
-            return new NoteInteraction(InteractionType, Flags, BlockPose, Positions, window);
+            return new NoteInteraction(InteractionType, Flags, BlockPose, Positions, window, HideIndicator);
         }
     }
 }


### PR DESCRIPTION
https://github.com/DoubleBrackets/SashimiSlayer/issues/114
- Fixed indicator visibility logic
- Added per-indicator toggle to hide indicator for potential clarity usage on tightly packed notes